### PR TITLE
Send correct id when create target

### DIFF
--- a/client/client-npc.lua
+++ b/client/client-npc.lua
@@ -47,7 +47,7 @@ CreateThread(function()
                                     label = locale('cl_open_barber'),
                                     targeticon = 'fa-solid fa-eye',
                                     action = function()
-                                        TriggerEvent('rsg-barber:client:menu', self.id)
+                                        TriggerEvent('rsg-barber:client:menu', v.id)
                                     end
                                 },
                             },


### PR DESCRIPTION
When using the Target to open the barbershop, it was returning the ID of `newpoint(1)` instead of the ID of the barber that was there (`blk-barbers` or any other defined in the config.lua).
